### PR TITLE
Add the rest of the missing graph features

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ graph.add_node(Node("node_a", value="hihi"))
 - [x] graph.adjacency_matrix() - Creates and returns an adjacency matrix (2-dimensional dictionary, using node id values as keys) for the graph.
 - [x] graph.add_all(elements) - Adds a list of Node and/or Edge elements to the graph.
 - [x] graph.remove_all(elements) - Removes a list of Node and/or Edge elements from the graph.
-- [ ] graph.random(order, size, connected=True, multigraph=False, initial_id=0) - Returns a list of randomly connected nodes and edges, with order specifying the amount of nodes and size specifying the amount of edges. If connected is set, a path will exist between any pair of nodes (unless the amount of edges makes this impossible). If multigraph is set, a pair of nodes may be connected by multiple edges. Nodes are assigned incremental id values starting at initial_id.
+- [x] graph.random(order, size~~, connected=True, multigraph=False, initial_id=0~~) - Returns a list of randomly connected nodes and edges, with order specifying the amount of nodes and size specifying the amount of edges. 
 - [x] graph.order(), graph.size() - Returns the number of nodes/edges in the graph.
 - [x] graph.clear() - Deletes all nodes and edges from the graph.
 Note: All functions containing node parameters accept either a Node instance or node id value.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ graph.add_node(Node("node_a", value="hihi"))
 - [x] graph.edges_between(node1, node2, directed=False) - Returns a list of all edges between node1 and node2. If directed is set, only edges beginning at node1 will be included.
  
 - [x] graph.set_directed(directed=True) - Sets whether all edges in the graph are directed.
-- [ ] graph.adjacency_matrix() - Creates and returns an adjacency matrix (2-dimensional dictionary, using node id values as keys) for the graph.
+- [x] graph.adjacency_matrix() - Creates and returns an adjacency matrix (2-dimensional dictionary, using node id values as keys) for the graph.
 - [x] graph.add_all(elements) - Adds a list of Node and/or Edge elements to the graph.
 - [x] graph.remove_all(elements) - Removes a list of Node and/or Edge elements from the graph.
 - [ ] graph.random(order, size, connected=True, multigraph=False, initial_id=0) - Returns a list of randomly connected nodes and edges, with order specifying the amount of nodes and size specifying the amount of edges. If connected is set, a path will exist between any pair of nodes (unless the amount of edges makes this impossible). If multigraph is set, a pair of nodes may be connected by multiple edges. Nodes are assigned incremental id values starting at initial_id.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ graph.add_node(Node("node_a", value="hihi"))
 - [x] graph.add_all(elements) - Adds a list of Node and/or Edge elements to the graph.
 - [x] graph.remove_all(elements) - Removes a list of Node and/or Edge elements from the graph.
 - [ ] graph.random(order, size, connected=True, multigraph=False, initial_id=0) - Returns a list of randomly connected nodes and edges, with order specifying the amount of nodes and size specifying the amount of edges. If connected is set, a path will exist between any pair of nodes (unless the amount of edges makes this impossible). If multigraph is set, a pair of nodes may be connected by multiple edges. Nodes are assigned incremental id values starting at initial_id.
-- [ ] graph.order(), graph.size() - Returns the number of nodes/edges in the graph.
+- [x] graph.order(), graph.size() - Returns the number of nodes/edges in the graph.
 - [x] graph.clear() - Deletes all nodes and edges from the graph.
 Note: All functions containing node parameters accept either a Node instance or node id value.
  

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ graph.add_node(Node("node_a", value="hihi"))
 - [x] graph.set_directed(directed=True) - Sets whether all edges in the graph are directed.
 - [ ] graph.adjacency_matrix() - Creates and returns an adjacency matrix (2-dimensional dictionary, using node id values as keys) for the graph.
 - [x] graph.add_all(elements) - Adds a list of Node and/or Edge elements to the graph.
-- [ ] graph.remove_all(elements) - Removes a list of Node and/or Edge elements from the graph.
+- [x] graph.remove_all(elements) - Removes a list of Node and/or Edge elements from the graph.
 - [ ] graph.random(order, size, connected=True, multigraph=False, initial_id=0) - Returns a list of randomly connected nodes and edges, with order specifying the amount of nodes and size specifying the amount of edges. If connected is set, a path will exist between any pair of nodes (unless the amount of edges makes this impossible). If multigraph is set, a pair of nodes may be connected by multiple edges. Nodes are assigned incremental id values starting at initial_id.
 - [ ] graph.order(), graph.size() - Returns the number of nodes/edges in the graph.
 - [x] graph.clear() - Deletes all nodes and edges from the graph.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ graph.add_node(Node("node_a", value="hihi"))
 - `outline` options on methods don't exist any more. Text no longer has any outlines.
 - You can no longer compare nodes with other nodes like `NodeA > NodeB`. To do this now, you need to specify the priority: `NodeA.priority() > NodeB.priority()`
 - The above also applies to edges.
-
+- `graph.random()` has been drastically simplified to just take `order` and `size` arguments.
 
 #### Todo
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ graph.add_node(Node("node_a", value="hihi"))
 - [x] graph.adjacent(node1, node2, directed=False) - Checks whether an edge exists between node1 and node2. If directed is set, the edge must begin at node1.
 - [x] graph.edges_between(node1, node2, directed=False) - Returns a list of all edges between node1 and node2. If directed is set, only edges beginning at node1 will be included.
  
-- [ ] graph.set_directed(directed=True) - Sets whether all edges in the graph are directed.
+- [x] graph.set_directed(directed=True) - Sets whether all edges in the graph are directed.
 - [ ] graph.adjacency_matrix() - Creates and returns an adjacency matrix (2-dimensional dictionary, using node id values as keys) for the graph.
 - [x] graph.add_all(elements) - Adds a list of Node and/or Edge elements to the graph.
 - [ ] graph.remove_all(elements) - Removes a list of Node and/or Edge elements from the graph.

--- a/pynode_next/graph.py
+++ b/pynode_next/graph.py
@@ -147,7 +147,7 @@ class Graph:
             elif isinstance(i, Edge):
                 self.add_edge(i)
             pause(20)
-    
+
     def remove_all(self, elements: Iterable[Union[Node, Edge]]):
         """Removes all node and edge objects from an iterable. all elements need to be of the type `Node` or `Edge`"""
         for i in elements:
@@ -226,12 +226,13 @@ class Graph:
                 # sets default connectedness
                 current_row[c._id] = 0
             matrix[r._id] = current_row
-        
+
         # sets the values correctly
         for r in self.nodes():
             for c in r.successor_nodes():
                 matrix[r._id][c._id] += 1
 
         return matrix
+
 
 graph = Graph()

--- a/pynode_next/graph.py
+++ b/pynode_next/graph.py
@@ -208,5 +208,12 @@ class Graph:
             i.set_directed(directed)
         return self
 
+    def order(self):
+        """Returns the order of the graph. that is, the number of nodes"""
+        return len(self._nodes)
+
+    def size(self):
+        """Returns the size of the graph. that is, the number of edges"""
+        return len(self._edges)
 
 graph = Graph()

--- a/pynode_next/graph.py
+++ b/pynode_next/graph.py
@@ -140,12 +140,13 @@ class Graph:
         return self.node(node) is not None
 
     def add_all(self, elements: Iterable[Union[Node, Edge]]):
-        """Adds all node and edge objects from an iterable"""
+        """Adds all node and edge objects from an iterable. all elements need to be of the type `Node` or `Edge`"""
         for i in elements:
             if isinstance(i, Node):
                 self.add_node(i)
             elif isinstance(i, Edge):
                 self.add_edge(i)
+            pause(20)
 
     def has_edge(self, edge):
         """Checks if an edge exists in the graph."""

--- a/pynode_next/graph.py
+++ b/pynode_next/graph.py
@@ -55,17 +55,13 @@ class Graph:
         """Returns the node with the id specified."""
         if id in self._nodes:
             return self._nodes[id]
-        raise NodeDoesntExistError(
-            f"The node '{id}' does not exist in the graph"
-        )
+        raise NodeDoesntExistError(f"The node '{id}' does not exist in the graph")
 
     @overloads(node)
     def node(self, node: Node):
         if node._id in self._nodes:
             return node
-        raise NodeDoesntExistError(
-            f"The node '{node._id}' does not exist in the graph"
-        )
+        raise NodeDoesntExistError(f"The node '{node._id}' does not exist in the graph")
 
     def nodes(self):
         """Returns all of the graph's nodes."""
@@ -176,11 +172,11 @@ class Graph:
         """Checks if an edge between nodeA and nodeB exists. If directed is True, then the edge must start from nodeA"""
         nodeA = self.node(nodeA)
         nodeB = self.node(nodeB)
-        
+
         node_list = nodeA.adjacent_nodes()
         if directed == True:
             node_list = nodeA.successor_nodes()
-        
+
         for n in node_list:
             if n is nodeB:
                 return True

--- a/pynode_next/graph.py
+++ b/pynode_next/graph.py
@@ -216,4 +216,22 @@ class Graph:
         """Returns the size of the graph. that is, the number of edges"""
         return len(self._edges)
 
+    def adjacency_matrix(self):
+        """Returns the adjacency matrix of the graph as a dictionary"""
+        matrix = {}
+        # goes through and creates an empty row for each node
+        for r in self.nodes():
+            current_row = {}
+            for c in self.nodes():
+                # sets default connectedness
+                current_row[c._id] = 0
+            matrix[r._id] = current_row
+        
+        # sets the values correctly
+        for r in self.nodes():
+            for c in r.successor_nodes():
+                matrix[r._id][c._id] += 1
+
+        return matrix
+
 graph = Graph()

--- a/pynode_next/graph.py
+++ b/pynode_next/graph.py
@@ -1,4 +1,5 @@
 from typing import Union, Iterable
+from random import randint, choices
 from .overloading import *
 
 from .misc import *
@@ -233,6 +234,22 @@ class Graph:
                 matrix[r._id][c._id] += 1
 
         return matrix
+
+    @staticmethod
+    def random(order, size):
+        """Returns a random list of edges and nodes that may or may not be connected."""
+        nodes = []
+        edges = []
+
+        for i in range(order):
+            nodes.append(Node(str(i)))
+
+        while len(edges) != size:
+            source_node, target_node = choices(population=nodes, k=2)
+            e = Edge(source_node, target_node)
+            edges.append(e)
+
+        return nodes + edges
 
 
 graph = Graph()

--- a/pynode_next/graph.py
+++ b/pynode_next/graph.py
@@ -191,5 +191,12 @@ class Graph:
         for n in ns:
             self.remove_node(n)
         return self
-        
+
+    def set_directed(self, directed=True):
+        """Sets whether or not all of the edges in the graph are directed."""
+        for i in self._edges:
+            i.set_directed(directed)
+        return self
+
+
 graph = Graph()

--- a/pynode_next/graph.py
+++ b/pynode_next/graph.py
@@ -147,6 +147,15 @@ class Graph:
             elif isinstance(i, Edge):
                 self.add_edge(i)
             pause(20)
+    
+    def remove_all(self, elements: Iterable[Union[Node, Edge]]):
+        """Removes all node and edge objects from an iterable. all elements need to be of the type `Node` or `Edge`"""
+        for i in elements:
+            if isinstance(i, Node):
+                self.remove_node(i)
+            elif isinstance(i, Edge):
+                self.remove_edge(i)
+            pause(20)
 
     def has_edge(self, edge):
         """Checks if an edge exists in the graph."""

--- a/test.py
+++ b/test.py
@@ -1,21 +1,11 @@
 from pynode_next import *
+import random
 
 def test():
-    
-    for i in "ab":
-        graph.add_node(i)
-    e = Edge("a", "b")
-    graph.add_edge(e)
-    pause(500)
-    e.set_weight(100)
-    e.set_weight_style(color=Color.RED)
-    core.ax(lambda x: x.nodes("cd").add())
-    core.ax(lambda x: x.edge("cd").add())
-    pause(500)
-    core.ax(lambda x: x.edge("cd").highlight().color("#fa0"))
-    pause(500)
-    e.highlight(color=Color.GREEN)
+    g = graph.random(4, 3)
+    print(g)
     ##graph.remove_edge(e)
-    print([str(i) for i in graph.node("a").adjacent_nodes()])
-
+    #print([str(i) for i in graph.node("a").adjacent_nodes()])
+    pause(500)
+    graph.add_all(g)
 begin_pynode_next(test)


### PR DESCRIPTION
Tries to implement all of the missing graph methods.

`graph.random()` is basically a different function to its original one. Now it only accepts `size` and `order` arguments. The old version was too complicated (and uncommented) for me to be able to rewrite it. In future we may want to add the other options (`connected`, `multigraph` and `initial_id`) back, but for now they aren't massively required.

