### PR TITLE
Add `Union` type support to overloading.py and allow types other than `str` as node ids

### DIFF
--- a/pynode_next/graph.py
+++ b/pynode_next/graph.py
@@ -8,6 +8,7 @@ from .errors import *
 from .edge import *
 from .core import core
 
+_generic_text = Union[str, int, float]
 
 class Graph:
     def __init__(self):
@@ -16,12 +17,12 @@ class Graph:
         self._has_edge_cache = {}
 
     @overloaded
-    def add_node(self, id: str):
+    def add_node(self, id: _generic_text):
         """Adds a node to the graph using an id."""
-        return self.add_node(id, id)
+        return self.add_node(Node(id, value=id))
 
     @overloads(add_node)
-    def add_node(self, id: str, value: str):
+    def add_node(self, id: _generic_text, value: _generic_text):
         """Adds a node to the graph using an id and a value."""
         if value == None:
             value = id
@@ -52,7 +53,7 @@ class Graph:
         return n
 
     @overloaded
-    def node(self, id: str):
+    def node(self, id: _generic_text):
         """Returns the node with the id specified."""
         if id in self._nodes:
             return self._nodes[id]

--- a/pynode_next/graph.py
+++ b/pynode_next/graph.py
@@ -57,13 +57,13 @@ class Graph:
         """Returns the node with the id specified."""
         if id in self._nodes:
             return self._nodes[id]
-        raise NodeDoesntExistError(f"The node '{id}' does not exist in the graph")
+        raise NodeDoesntExistError(f"The node '{id}' <{type(id).__name__}> does not exist in the graph")
 
     @overloads(node)
     def node(self, node: Node):
         if node._id in self._nodes:
             return node
-        raise NodeDoesntExistError(f"The node '{node._id}' does not exist in the graph")
+        raise NodeDoesntExistError(f"The node '{node._id}' <{type(id).__name__}> does not exist in the graph")
 
     def nodes(self):
         """Returns all of the graph's nodes."""

--- a/test.py
+++ b/test.py
@@ -1,11 +1,13 @@
+import inspect
+from typing import Iterable, List, Union, get_args, _UnionGenericAlias
 from pynode_next import *
 import random
 
 def test():
-    g = graph.random(4, 3)
-    print(g)
-    ##graph.remove_edge(e)
-    #print([str(i) for i in graph.node("a").adjacent_nodes()])
-    pause(500)
-    graph.add_all(g)
+    graph.add_node("1")
+    graph.add_node(2)
+    graph.add_edge("1", 2)
+
+    print(graph.node(1))
+
 begin_pynode_next(test)


### PR DESCRIPTION
brings the features more inline with the original PyNode. Before this pr, PyNode-Next would freak out if there was an int passed as an argument to `graph.add_node()`. This pr should fix it.