### PR TITLE
remove-legacy-arguments-ehn-27

### DIFF
--- a/docs/documentation.adoc
+++ b/docs/documentation.adoc
@@ -454,13 +454,10 @@ Gets the node's priority value.
 === set_position
 [source, python]
 ----
-node.set_position(x, y, relative=True)
+node.set_position(x, y)
 ----
 
 Sets the node's position on the canvas. Uses relative positions whereby (0, 0) is the bottom-left corner and (1, 1) is the top-right corner.
-
-WARNING: The relative option is a legacy argument from PyNode. PyNode Next only supports the relative positioning system. If you try to set relative to `False`, it will throw an error.
-
 
 [cols="a,a", width="100%", options="header"]
 |===
@@ -558,8 +555,6 @@ node.set_value_style(size=13, color=Color.WHITE)
 
 Sets the appearance of the node's value text.
 
-WARNING: PyNode supported an argument `outline` to change the text outline's color. PyNode Next does not support this argument, and will print a warning if you try to set it.
-
 [cols="a,a", width="100%", options="header"]
 |===
 | Argument | Accepted Types
@@ -574,10 +569,6 @@ node.set_label_style(size=10, color=Color.GREY, label_id=0)
 ----
 
 Sets the appearance of the node's label text.
-
-WARNING: PyNode supported an argument `outline` to change the text outline's color. PyNode Next does not support this argument, and will print a warning if you try to set it.
-
-CAUTION: Always use the keyword argument to choose the `label_id`. This is because PyNode placed the `outline` argument in the third argument location (`node.set_label_style(size=10, color=Color.GREY, outline=None, label_id=None)`). And to maintain backwards compatibility with PyNode, PyNode Next still has the `outline` argument in that position, even though it does nothing. 
 
 [cols="a,a", width="100%", options="header"]
 |===
@@ -802,8 +793,6 @@ edge.set_weight_style(size=10, color=Color.GREY)
 ----
 
 Sets the appearance of the edge's weight label.
-
-WARNING: PyNode supported an argument `outline` to change the text outline's color. PyNode Next does not support this argument, and will print a warning if you try to set it.
 
 [cols="a,a", width="100%", options="header"]
 |===

--- a/pynode_next/edge.py
+++ b/pynode_next/edge.py
@@ -93,10 +93,8 @@ class Edge:
         """Returns the edge's weight. Returns an empty string if weight wasn't defined at init and hasn't been changed since."""
         return self._weight
 
-    def set_weight_style(self, size=10, color=Color.GREY, outline=None):
+    def set_weight_style(self, size=10, color=Color.GREY):
         """Sets the edge's weight text style. These styles are not saved."""
-        if outline is not None:
-            print("set_weight_style(outline) is not supported by PyNode_Next")
 
         self.__ax(
             lambda x: self._dispatch_wrapper(

--- a/pynode_next/node.py
+++ b/pynode_next/node.py
@@ -47,9 +47,7 @@ class Node:
         """Returns the node's value."""
         return self._value
 
-    def set_value_style(self, size=13, color=Color.WHITE, outline=None):
-        if outline is not None:
-            print("set_value_style(outline) is not supported by PyNode_Next")
+    def set_value_style(self, size=13, color=Color.WHITE):
         self.__ax(lambda x: x.node(self._id).label().size(size).color(str(color)))
         return self
 

--- a/pynode_next/node.py
+++ b/pynode_next/node.py
@@ -187,11 +187,8 @@ class Node:
                 node_list.append(e._target)
         return node_list
 
-    def set_position(self, x, y, relative=True):
         """Sets the node's position. Relative is the only style you can use"""
-        if not relative:
-            raise NodePositionError("Cannot call node.set_position() with relative=False")
-        
+    def set_position(self, x, y):
         self._pos = [x, y]
         
         x_norm = core.normalise_to_canvas(x)

--- a/pynode_next/node.py
+++ b/pynode_next/node.py
@@ -187,8 +187,8 @@ class Node:
                 node_list.append(e._target)
         return node_list
 
-        """Sets the node's position. Relative is the only style you can use"""
     def set_position(self, x, y):
+        """Sets the node's position. (0, 0) is the bottom left of the screen, (1, 1) is the top right"""
         self._pos = [x, y]
         
         x_norm = core.normalise_to_canvas(x)

--- a/pynode_next/node.py
+++ b/pynode_next/node.py
@@ -125,10 +125,8 @@ class Node:
     def label(self, label_id=0):
         return self._labels[label_id]
 
-    def set_label_style(self, size=10, color=Color.GREY, outline=None, label_id=None):
+    def set_label_style(self, size=10, color=Color.GREY, label_id=None):
         """Sets the style of any labels"""
-        if outline is not None:
-            print("set_label_style(outline) is not supported by PyNode Next")
         if label_id is None:
             self.__ax(lambda x: x.node(self._id).label('tr').size(size).color(str(color)))
             self.__ax(lambda x: x.node(self._id).label('tl').size(size).color(str(color)))


### PR DESCRIPTION
Removes legacy arguments from PyNode Next. (Thankfully none of them used the overloading system so the errors should be at least useful)

Closes #26 EHN-27