### PR TITLE
fix-the-edge-weight-none-problem-ehn-17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ dmypy.json
 
 
 .vscode
+.idea
 
 test.adoc
 test.html

--- a/docs/documentation.adoc
+++ b/docs/documentation.adoc
@@ -99,7 +99,7 @@ Returns a list of all the nodes currently in the graph as `Node` objects.
 === add_edge
 [source, python]
 ----
-graph.add_edge(source, target, weight=None, directed=False) # <.>
+graph.add_edge(source, target, weight="", directed=False) # <.>
 graph.add_edge(edge) # <.>
 ----
 
@@ -598,12 +598,10 @@ Plays a highlight animation where the node's color changes to that specified.
 === \\__init__
 [source, python]
 ----
-Edge(source, target, weight=None, directed=False)
+Edge(source, target, weight="", directed=False)
 ----
 
 Creates an edge between the `source` and `target` nodes. If `weight` is set, the edge will display it as a label. If `directed` is set, the edge will be directed, starting at the `source` node.
-
-CAUTION: If `weight` is initially set to `None`, there will be no label text. However, if you later use `edge.set_weight()` to change it to `None`, then it will display "None" as a label.
 
 [cols="a,a", width="100%", options="header"]
 |===

--- a/pynode_next/edge.py
+++ b/pynode_next/edge.py
@@ -5,14 +5,12 @@ from .core import core
 
 
 class Edge:
-    def __init__(self, source, target, weight=None, directed=False):
+    def __init__(self, source, target, weight="", directed=False):
         self._source = source
         self._target = target
         self._directed = directed
 
         self._weight = weight
-        if weight is None:
-            self._weight = ""
 
         self._thickness = 2
         self._priority = 0

--- a/pynode_next/graph.py
+++ b/pynode_next/graph.py
@@ -75,7 +75,7 @@ class Graph:
         return list(self._nodes.values())
 
     @overloaded
-    def add_edge(self, source, target, weight=None, directed: bool = False):
+    def add_edge(self, source, target, weight="", directed: bool = False):
         """Adds an edge by defining it's relation to other nodes."""
         return self.add_edge(Edge(source, target, weight, directed))
 

--- a/test.py
+++ b/test.py
@@ -1,12 +1,10 @@
-import inspect
-from sys import excepthook
-from types import DynamicClassAttribute
-from typing import Iterable, List, Union, final, get_args
 from pynode_next import *
+import time
 
 
 def test():
-    a = graph.add_node('a')
-    a.set_position(0,0)
+    graph.add_node('a')
+    graph.add_node('b')
+    graph.add_edge('a', 'b', 'hello!')
 
 begin_pynode_next(test)


### PR DESCRIPTION
Fixes the problem where you'd have to double set the edge's weight to None if you wanted it to be None.

before:

```py
graph.add_edge('a', 'b', weight=None, directed=False)
# doesn't show the weight 'None'
edge.set_weight(None)
# now it does
```

after:

```py
graph.add_edge('a', 'b', weight=None, directed=False)
# shows the weight 'None'
```


---

 Closes #13 and  EHN-17